### PR TITLE
Add Temporary CNAME record

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+beta.iliosproject.org


### PR DESCRIPTION
Temporarily redirect traffic to beta.iliosproject.org to show that this site is incomplete.

I already added a CNAME to our bluehost DNS record so this should work once it is merged.

Fixes #1