### PR TITLE
host site under iliosproject.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+iliosproject.org


### PR DESCRIPTION
currently, iliosproject.org redirects to ilios.github.io.

refs #16

let's fix that.

**ACHTUNG!** this will require additional configuration, see https://help.github.com/articles/adding-a-cname-file-to-your-repository/.